### PR TITLE
feat: Add regex-based message filtering to EventSelector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Kubernetes controller built with Kubebuilder framework. The controller manages `RemediationPolicy` custom resources (CRDs) to watch and respond to Kubernetes events.
+DevOps AI Toolkit Controller - A Kubernetes controller built with Kubebuilder v4.7.1. The controller provides two main capabilities:
+
+1. **Solution CRD** (`dot-ai.devopstoolkit.live/v1alpha1`): Resource tracking and lifecycle management
+   - Groups related Kubernetes resources as logical solutions
+   - Manages ownerReferences for automatic cleanup
+   - Aggregates health status across tracked resources
+   - Standalone feature - no external dependencies
+
+2. **RemediationPolicy CRD** (`dot-ai.devopstoolkit.live/v1alpha1`): Event-driven remediation
+   - Watches Kubernetes events with configurable filtering
+   - Integrates with DevOps AI Toolkit MCP for AI-powered remediation
+   - Supports automatic and manual modes
+   - Includes rate limiting and Slack notifications
+   - Requires external MCP endpoint
 
 ## Development Commands
 
@@ -16,14 +29,18 @@ make build
 # Run locally (requires kubeconfig)
 make run
 
-# Run all tests
+# Run all tests (unit + integration using envtest)
 make test
 
 # Run unit tests only
 go test $(go list ./... | grep -v /e2e)
 
-# Run e2e tests (creates Kind cluster)
+# Run e2e tests (creates Kind cluster named 'controller-init-test-e2e')
+# Uses isolated kubeconfig 'e2e-kubeconfig' in current directory
 make test-e2e
+
+# Cleanup e2e cluster when done
+make cleanup-test-e2e
 ```
 
 ### Code Generation (Required after API changes)
@@ -70,19 +87,55 @@ make docker-push IMG=<registry>/controller:tag
 make docker-buildx IMG=<registry>/controller:tag
 ```
 
+### Development Environment Setup
+```bash
+# Full development environment using Nushell scripts
+# Sets up Kind cluster with all dependencies
+./dot.nu setup \
+  --dot-ai-tag "0.144.0" \
+  --kubernetes-provider "kind" \
+  --crossplane-enabled true \
+  --kyverno-enabled true
+
+# Teardown development environment
+./dot.nu destroy
+```
+
 ## Architecture
 
 ### Kubebuilder Structure
-- **API Definition**: `api/v1alpha1/remediationpolicy_types.go` - Defines the RemediationPolicy CRD schema
-- **Controller**: `internal/controller/remediationpolicy_controller.go` - Reconciliation logic
-- **Main Entry**: `cmd/main.go` - Sets up manager and starts controller
-- **Configuration**: `config/` directory contains Kustomize manifests for deployment
+- **API Definitions**: `api/v1alpha1/`
+  - `solution_types.go` - Solution CRD schema for resource tracking
+  - `remediationpolicy_types.go` - RemediationPolicy CRD schema for event remediation
+- **Controllers**: `internal/controller/`
+  - `solution_controller.go` - Manages Solution CRs and ownerReferences
+  - `remediationpolicy_controller.go` - Watches events and triggers remediation
+- **Main Entry**: `cmd/main.go` - Sets up manager and registers both controllers
+- **Configuration**: `config/` directory contains Kustomize manifests
+  - `config/crd/bases/` - Generated CRD definitions
+  - `config/manager/` - Controller deployment manifests
+  - `config/samples/` - Example custom resources
 
 ### Key Patterns
-- **Reconciliation Loop**: Controller implements the Reconcile method to handle RemediationPolicy changes
+
+**Solution Controller:**
+- Reconciles Solution CRs by setting ownerReferences on tracked resources
+- Aggregates health status from all child resources
+- Uses exponential backoff with jitter for retries
+- Updates status with detailed resource conditions
+
+**RemediationPolicy Controller:**
+- Watches Kubernetes Events cluster-wide using MapFunc
+- Implements deduplication to prevent processing same event multiple times
+- Rate limiting per policy+object+reason with configurable cooldowns
+- HTTP client calls external MCP endpoint for remediation analysis
+- Supports per-selector overrides for mode, confidence, and risk level
+
+**Common Patterns:**
 - **RBAC Markers**: Use `+kubebuilder:rbac` comments to generate RBAC manifests
-- **Status Updates**: CRD includes Status subresource for tracking operational state
+- **Status Updates**: Both CRDs include Status subresource for operational state
 - **Generated Code**: DeepCopy methods and CRD manifests are auto-generated - never edit manually
+- **Structured Logging**: Use `logf.FromContext(ctx)` for consistent logging
 
 ### Adding New Controllers or APIs
 ```bash
@@ -114,13 +167,37 @@ Test files follow Go convention: `*_test.go` alongside source files.
 ## Dependencies
 
 - **Go**: 1.24.0+
-- **Kubebuilder**: Project scaffolded with Kubebuilder v3.x
+- **Kubebuilder**: Project scaffolded with Kubebuilder v4.7.1
 - **controller-runtime**: v0.21.0 - Main framework for building controllers
 - **Kubernetes APIs**: v0.33.0
+- **Testing**: Ginkgo v2.22.0 + Gomega v1.36.1
+
+## Repository Structure
+
+```
+dot-ai-controller/
+├── api/v1alpha1/           # CRD API definitions (Solution, RemediationPolicy)
+├── internal/controller/    # Controller implementations
+├── cmd/main.go            # Application entry point
+├── config/                # Kustomize manifests (CRDs, RBAC, deployment)
+├── charts/                # Helm chart for installation
+├── docs/                  # User documentation (setup, guides, troubleshooting)
+├── examples/              # Example manifests
+├── scripts/               # Nushell utility scripts for development setup
+├── test/e2e/              # End-to-end tests using Kind
+├── prds/                  # Product requirement documents
+└── dot.nu                 # Main development environment script
+```
 
 ## Important Notes
 
-- Always run `make generate manifests` after modifying API types
-- RBAC permissions are generated from controller comments - update them as needed
-- The controller uses a shared informer cache - avoid direct API calls when possible
-- Follow Kubebuilder conventions for controller implementation
+- **Code Generation**: Always run `make generate manifests` after modifying API types in `api/v1alpha1/*_types.go`
+- **RBAC**: Permissions are generated from `+kubebuilder:rbac` comments in controller files - update them as needed
+- **Informer Cache**: The controller uses a shared informer cache - avoid direct API calls when possible
+- **Status Updates**: Use `r.Status().Update()` for status changes, not `r.Update()`
+- **ownerReferences**: Solution controller sets these automatically - don't manually manage them
+- **Event Deduplication**: RemediationPolicy controller tracks processed events in-memory - state is lost on restart
+- **Rate Limiting**: Configured per policy+object+reason to prevent storms while allowing different objects to be processed
+- **External Dependencies**: RemediationPolicy requires MCP endpoint; Solution CRD works standalone
+- **Helm Chart**: Located in `charts/dot-ai-controller/` and published as OCI artifact to GHCR
+- **Documentation**: User-facing docs in `docs/`, PRDs track feature development in `prds/`

--- a/api/v1alpha1/remediationpolicy_types.go
+++ b/api/v1alpha1/remediationpolicy_types.go
@@ -41,6 +41,12 @@ type EventSelector struct {
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
+	// Message pattern to match against event message (supports regex)
+	// If specified, only events whose message matches this regex pattern will be selected
+	// Empty string acts as wildcard (matches all messages)
+	// +optional
+	Message string `json:"message,omitempty"`
+
 	// Remediation mode for this specific selector: "manual" or "automatic"
 	// Overrides the global policy mode when specified
 	// +kubebuilder:validation:Enum=manual;automatic

--- a/config/crd/bases/dot-ai.devopstoolkit.live_remediationpolicies.yaml
+++ b/config/crd/bases/dot-ai.devopstoolkit.live_remediationpolicies.yaml
@@ -99,6 +99,12 @@ spec:
                       - medium
                       - high
                       type: string
+                    message:
+                      description: |-
+                        Message pattern to match against event message (supports regex)
+                        If specified, only events whose message matches this regex pattern will be selected
+                        Empty string acts as wildcard (matches all messages)
+                      type: string
                     mode:
                       description: |-
                         Remediation mode for this specific selector: "manual" or "automatic"

--- a/docs/remediation-guide.md
+++ b/docs/remediation-guide.md
@@ -326,6 +326,64 @@ eventSelectors:
 
 **Important**: Selectors are evaluated in order. The first matching selector's configuration is used.
 
+### Message Filtering
+
+Filter events based on message content using regex patterns:
+
+```yaml
+eventSelectors:
+  - type: Warning
+    reason: BackOff
+    message: "pulling image.*nginx"     # Regex pattern to match event message
+```
+
+**Pattern Syntax**: Uses Go regex syntax (RE2). Common patterns:
+- `.*` - Match any characters
+- `^` - Start of string
+- `$` - End of string
+- `(?i)` - Case-insensitive flag
+- `[0-9]+` - One or more digits
+
+**Examples**:
+
+```yaml
+# Match specific image pull failures
+eventSelectors:
+  - type: Warning
+    reason: BackOff
+    message: "Failed to pull image.*postgres"
+
+# Match any error code in message
+eventSelectors:
+  - type: Warning
+    message: "error code [0-9]+"
+
+# Case-insensitive matching for timeout messages
+eventSelectors:
+  - type: Warning
+    message: "(?i)timeout"
+
+# Match OOMKilled messages
+eventSelectors:
+  - type: Warning
+    reason: BackOff
+    involvedObjectKind: Pod
+    message: "Container.*was OOMKilled"
+
+# Combine filters - match BackOff events with specific messages
+eventSelectors:
+  - type: Warning
+    reason: BackOff
+    involvedObjectKind: Pod
+    namespace: preprod
+    message: "Back-off.*pulling image"
+    mode: manual
+    confidenceThreshold: 0.85
+    maxRiskLevel: medium
+```
+
+**Wildcard**: Empty or omitted `message` field matches all events (no message filtering).
+
 ### Mode Configuration
 
 ```yaml


### PR DESCRIPTION
## Summary

Add support for filtering Kubernetes events by message content using regex patterns. This enables more precise event selection for remediation policies.

## Motivation

Currently, EventSelector filters events by Type, Reason, InvolvedObjectKind, and Namespace. However, these fields alone cannot distinguish between different variants of the same event type. For example:
- All \`BackOff\` events have the same reason, regardless of cause
- Cannot filter for specific image pull failures vs. OOMKilled backoffs
- Cannot target events with specific error codes or patterns

This PR adds message-based filtering to enable more granular event selection.

## Changes

### API Changes
- **EventSelector**: Added optional \`message\` field supporting regex patterns
  - Uses Go RE2 regex syntax
  - Empty/omitted = wildcard (backward compatible)
  - Placed after basic filters, before override fields

### Controller Implementation
- **matchesSelector()**: Added regex-based message filtering
  - Uses \`regexp.MatchString()\` for pattern matching
  - Handles invalid regex gracefully (logs error, returns false)
  - Consistent with existing filter pattern

### Testing
- Added 7 comprehensive test cases covering:
  - ✅ Regex pattern matching
  - ✅ Non-matching messages
  - ✅ Wildcard behavior (empty string)
  - ✅ Invalid regex error handling
  - ✅ Case-sensitive matching
  - ✅ Case-insensitive matching
  - ✅ Combined filters
- All tests passing: 76.8% coverage

### Documentation
- Added "Message Filtering" section to \`docs/remediation-guide.md\`
- Includes regex syntax guide and practical examples
- Updated \`CLAUDE.md\` with implementation details

## Example Usage

\`\`\`yaml
eventSelectors:
  # Match specific image pull failures
  - type: Warning
    reason: BackOff
    message: "Failed to pull image.*postgres"

  # Match OOMKilled backoffs only
  - type: Warning
    reason: BackOff
    involvedObjectKind: Pod
    message: "Container.*was OOMKilled"

  # Case-insensitive timeout detection
  - type: Warning
    message: "(?i)timeout"

  # Match error codes
  - type: Warning
    message: "error code [0-9]+"
\`\`\`

## Backward Compatibility

✅ **Fully backward compatible**:
- Message field is optional
- Empty/omitted = no message filtering (current behavior)
- Existing RemediationPolicies work unchanged
- No breaking changes

## Testing

\`\`\`bash
# All tests pass
make test

# CRD generation clean
make generate manifests

# Linting passes
make fmt vet
\`\`\`

## Checklist

- [x] Added unit tests
- [x] Updated documentation
- [x] Regenerated CRD manifests
- [x] All tests passing
- [x] Backward compatible
- [x] Follows existing code patterns

## Related Issues

N/A - New feature implementation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added message-based event filtering using regex patterns for RemediationPolicy events. Empty message fields act as wildcards.

* **Documentation**
  * Updated architecture documentation with dual-CRD design, development workflows, and environment setup guidance.
  * Added event filtering examples with regex syntax and pattern matching details.

* **Tests**
  * Added comprehensive test coverage for message-based event filtering scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->