### PR TITLE
fix: improve MCP request handling and rate limiting

### DIFF
--- a/internal/controller/remediationpolicy_controller.go
+++ b/internal/controller/remediationpolicy_controller.go
@@ -36,9 +36,9 @@ type RemediationPolicyReconciler struct {
 	processedEventsMu sync.RWMutex
 
 	// Rate limiting - tracks policy processing per minute and cooldown periods
-	// Key format: policy-namespace/policy-name/involved-object-namespace/involved-object-name/event-reason
-	rateLimitTracking map[string][]time.Time // Track processing times per policy+object+reason
-	cooldownTracking  map[string]time.Time   // Track cooldown periods per policy+object+reason
+	// Key format: policy-namespace/policy-name/involved-object-namespace/involved-object-name
+	rateLimitTracking map[string][]time.Time // Track processing times per policy+object
+	cooldownTracking  map[string]time.Time   // Track cooldown periods per policy+object
 	rateLimitMu       sync.RWMutex
 }
 

--- a/internal/controller/remediationpolicy_mcp.go
+++ b/internal/controller/remediationpolicy_mcp.go
@@ -239,6 +239,7 @@ func (r *RemediationPolicyReconciler) sendMcpRequest(ctx context.Context, mcpReq
 
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
 	req.Header.Set("User-Agent", "dot-ai-controller/v1.0.0")
 
 	// Add Authorization header if auth token is configured
@@ -247,7 +248,7 @@ func (r *RemediationPolicyReconciler) sendMcpRequest(ctx context.Context, mcpReq
 		logger.V(1).Info("Authorization header set for MCP request")
 	}
 
-	logger.Info("🌐 Sending HTTP request", "method", "POST", "headers", req.Header)
+	logger.Info("🌐 Sending HTTP request", "method", "POST", "endpoint", endpoint)
 
 	// Make the HTTP request
 	resp, err := r.HttpClient.Do(req)

--- a/internal/controller/remediationpolicy_ratelimit_test.go
+++ b/internal/controller/remediationpolicy_ratelimit_test.go
@@ -524,7 +524,7 @@ var _ = Describe("RemediationPolicy Rate Limiting", func() {
 
 					key := reconciler.getRateLimitKey(ctx, policy, event)
 
-					expectedKey := fmt.Sprintf("%s/rate-limit-policy/%s/standalone-pod/BackOff", testNs, testNs)
+					expectedKey := fmt.Sprintf("%s/rate-limit-policy/%s/standalone-pod", testNs, testNs)
 					Expect(key).To(Equal(expectedKey))
 				})
 			})
@@ -622,7 +622,7 @@ var _ = Describe("RemediationPolicy Rate Limiting", func() {
 
 					key := reconciler.getRateLimitKey(ctx, policy, event)
 
-					expectedKey := fmt.Sprintf("%s/rate-limit-policy/%s/cronjob:test-cronjob/BackOff", testNs, testNs)
+					expectedKey := fmt.Sprintf("%s/rate-limit-policy/%s/cronjob:test-cronjob", testNs, testNs)
 					Expect(key).To(Equal(expectedKey))
 				})
 			})
@@ -749,7 +749,7 @@ var _ = Describe("RemediationPolicy Rate Limiting", func() {
 					// Both keys should be identical - this is the core requirement!
 					Expect(key1).To(Equal(key2))
 
-					expectedKey := fmt.Sprintf("%s/rate-limit-policy/%s/cronjob:shared-cronjob/BackOff", testNs, testNs)
+					expectedKey := fmt.Sprintf("%s/rate-limit-policy/%s/cronjob:shared-cronjob", testNs, testNs)
 					Expect(key1).To(Equal(expectedKey))
 				})
 			})
@@ -771,7 +771,7 @@ var _ = Describe("RemediationPolicy Rate Limiting", func() {
 
 					key := reconciler.getRateLimitKey(ctx, policy, event)
 
-					expectedKey := fmt.Sprintf("%s/rate-limit-policy/%s/my-deployment/ScalingReplicaSet", testNs, testNs)
+					expectedKey := fmt.Sprintf("%s/rate-limit-policy/%s/my-deployment", testNs, testNs)
 					Expect(key).To(Equal(expectedKey))
 				})
 			})


### PR DESCRIPTION
## Summary

- **Security**: Remove Authorization header from log output to prevent credential exposure in logs
- **Bug Fix**: Add `Accept: application/json, text/event-stream` header required by MCP servers (fixes HTTP 406 errors)
- **Bug Fix**: Remove `event.Reason` from rate limit key so all events for the same object share one cooldown bucket

## Problem

1. **Credential Exposure**: The controller was logging HTTP request headers including the Bearer token, exposing credentials in logs
2. **MCP 406 Error**: MCP servers require clients to accept both `application/json` and `text/event-stream` content types
3. **Notification Storms**: Different event reasons (Failed, ErrImagePull, ImagePullBackOff) for the same pod bypassed rate limiting because each reason had its own cooldown bucket

## Changes Made

- `remediationpolicy_mcp.go`: 
  - Removed headers from log output, replaced with endpoint
  - Added `Accept` header for MCP compatibility
- `remediationpolicy_ratelimit.go`:
  - Removed `event.Reason` from rate limit key
  - Updated documentation to explain the new behavior
- `remediationpolicy_controller.go`:
  - Updated comments describing rate limit key format
- `remediationpolicy_ratelimit_test.go`:
  - Updated test assertions to match new key format

## Testing

- All unit and integration tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified rate limiting and cooldown tracking for remediation policies to consolidate events per object.
  * Enhanced HTTP request compatibility by adding Accept header for MCP communication.
  * Refined logging to display endpoint URLs instead of request headers for improved clarity.

* **Tests**
  * Updated test cases to reflect simplified rate limit key format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->