### PR TITLE
fix(resourcesync): prevent infinite reconciliation loop on etcd size limit

### DIFF
--- a/changelog.d/42.bugfix.md
+++ b/changelog.d/42.bugfix.md
@@ -1,0 +1,7 @@
+**Fix Infinite Reconciliation Loop When Status Exceeds etcd Size Limit**
+
+Resolves an issue where the ResourceSyncConfig controller would enter an infinite reconciliation loop when the status object grew too large, exceeding etcd's 3MB object size limit. This caused massive CPU usage and log flooding as the controller repeatedly attempted status updates that could never succeed.
+
+The controller now caps the `SyncErrors` counter at 100,000 to prevent unbounded growth and truncates error messages to 1KB maximum. When status updates fail due to "entity too large" errors, the controller enters a 5-minute backoff period instead of retrying immediately. All status fields are sanitized before each update to ensure they fit within etcd limits.
+
+If you encounter this issue before upgrading, the workaround is to delete and recreate the affected ResourceSyncConfig to reset its status.


### PR DESCRIPTION
## Summary

- **Caps `SyncErrors` counter at 100,000** to prevent unbounded growth that could cause status updates to exceed etcd's 3MB object size limit
- **Truncates error messages to 1KB maximum** to prevent status bloat from accumulated error strings
- **Implements 5-minute backoff** when status updates fail due to size limits, instead of immediate retry that caused infinite loops
- **Sanitizes all status fields before each update** ensuring they fit within etcd limits

## Test plan

- [x] Unit tests added for all new functions (`isEntityTooLargeError`, `sanitizeStatus`, `truncateErrorMessage`, `incrementSyncErrors`)
- [x] Unit tests added for backoff behavior tracking
- [x] Existing integration tests continue to pass
- [ ] Manual verification in cluster with large status object (optional - workaround documented)

## Related Issues

Closes #42

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved infinite reconciliation loops caused by ResourceSyncConfig status growth.
  * Implemented automatic limits and backoff mechanism for resilient status updates.
  * Recommended workaround: recreate affected ResourceSyncConfig to reset status prior to upgrade.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->