### PR TITLE
chore: add agent helper scripts to devbox

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -20,6 +20,9 @@
       "[ -n \"$USE_VALS\" ] && eval \"$(vals env -export -f .env.vals.yaml)\" || true",
       "[ -f .env ] && source .env || true"
     ],
-    "scripts": {}
+    "scripts": {
+      "agent": ["claude --continue"],
+      "agent-new": ["claude"]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds two convenience scripts to `devbox.json` for invoking Claude Code:

- `agent` — runs `claude --continue` (resume the most recent session)
- `agent-new` — runs `claude` (start a fresh session)

Tooling-only change. No source code, CI, or runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)