### PR TITLE
docs: add required mcpAuthSecretRef to RemediationPolicy examples

### DIFF
--- a/changelog.d/+remediationpolicy-docs-auth.doc.md
+++ b/changelog.d/+remediationpolicy-docs-auth.doc.md
@@ -1,0 +1,5 @@
+## RemediationPolicy Docs Now Include Required mcpAuthSecretRef
+
+The RemediationPolicy quickstart in `docs/index.md` and the API reference table in `examples/docs/api-reference.md` previously omitted `mcpAuthSecretRef`, even though the CRD marks it required. Users copying the published examples hit either a CRD validation error or silent `HTTP 401` failures from the MCP server with no remediation ever running ([#53](https://github.com/vfarcic/dot-ai-controller/issues/53)).
+
+The quickstart now creates `dot-ai-secrets` and references it via `mcpAuthSecretRef`, mirroring the ResourceSyncConfig pattern. The API reference table marks `mcpAuthSecretRef` as required.

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,6 +128,11 @@ This installs all five CRDs (Solution, RemediationPolicy, ResourceSyncConfig, Ca
 First, install the [DevOps AI Toolkit MCP](https://devopstoolkit.ai/docs/mcp), then:
 
 ```bash
+# Create a secret with your MCP auth token (if not already created)
+kubectl create secret generic dot-ai-secrets \
+  --namespace dot-ai \
+  --from-literal=auth-token=your-auth-token-here
+
 # Create a RemediationPolicy to handle events
 kubectl apply --filename - <<'EOF'
 apiVersion: dot-ai.devopstoolkit.live/v1alpha1
@@ -141,6 +146,9 @@ spec:
       reason: FailedScheduling
       mode: automatic
   mcpEndpoint: http://dot-ai-mcp.dot-ai.svc.cluster.local:3456/api/v1/tools/remediate
+  mcpAuthSecretRef:
+    name: dot-ai-secrets
+    key: auth-token
   mode: manual
 EOF
 ```

--- a/examples/docs/api-reference.md
+++ b/examples/docs/api-reference.md
@@ -110,6 +110,7 @@ The RemediationPolicy CRD enables event-driven remediation with AI-powered analy
 | eventSelectors | []EventSelector | Yes | Filters for Kubernetes events |
 | mode | string | No | Execution mode (automatic, manual) |
 | mcpEndpoint | string | Yes | MCP server endpoint |
+| mcpAuthSecretRef | SecretRef | Yes | Secret containing MCP auth token (Bearer) |
 | rateLimiting | RateLimitConfig | No | Rate limiting configuration |
 
 ### Status Fields


### PR DESCRIPTION
## Summary

- Fixes #53: RemediationPolicy quickstart in `docs/index.md` and API reference in `examples/docs/api-reference.md` omitted the required `mcpAuthSecretRef` field, causing copy-paste users to hit CRD validation errors or silent HTTP 401 failures from MCP.
- Updates the quickstart to create `dot-ai-secrets` and reference it via `mcpAuthSecretRef`, mirroring the ResourceSyncConfig pattern just below.
- Adds the `mcpAuthSecretRef` row (marked Required) to the RemediationPolicy spec table.

## Test plan

- [x] Verified CRD lists `mcpAuthSecretRef` under `required` (`config/crd/bases/dot-ai.devopstoolkit.live_remediationpolicies.yaml`)
- [x] Verified `docs/remediation-guide.md` already follows this pattern (model for the fix)
- [ ] Docs render check on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start and API reference to document the newly required `mcpAuthSecretRef` field for RemediationPolicy configurations.
  * Added step-by-step guidance for creating and referencing the necessary Kubernetes secret containing MCP authentication credentials.
  * Resolves potential validation errors and silent authentication failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-ai-controller/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->