### PR TITLE
Fix/55 capability scan reconciliation

### DIFF
--- a/internal/controller/capabilityscan_controller.go
+++ b/internal/controller/capabilityscan_controller.go
@@ -233,29 +233,48 @@ func (r *CapabilityScanReconciler) performStartupReconciliation(ctx context.Cont
 	logger.Info("Starting reconciliation", "config", configKey)
 
 	// List all resources in cluster using Discovery API (with filters applied)
-	clusterResources, err := r.listAllResourceIDs(ctx, state.config)
+	clusterResources, clusterComplete, err := r.listAllResourceIDs(ctx, state.config)
 	if err != nil {
 		logger.Error(err, "❌ Failed to list cluster resources")
 		r.updateStatusByKey(ctx, configKey, false, err.Error())
 		return
 	}
-	logger.Info("Found cluster resources", "count", len(clusterResources))
+	logger.Info("Found cluster resources", "count", len(clusterResources), "complete", clusterComplete)
 
-	// List all capability IDs from MCP
-	mcpCapabilities, err := state.mcpClient.ListCapabilityIDs(ctx)
+	// List all capabilities from MCP (id for deletion, resourceName for matching)
+	mcpCaps, mcpComplete, err := state.mcpClient.ListCapabilityInfos(ctx)
 	if err != nil {
 		logger.Error(err, "❌ Failed to list MCP capabilities")
 		r.updateStatusByKey(ctx, configKey, false, err.Error())
 		return
 	}
-	logger.Info("Found MCP capabilities", "count", len(mcpCapabilities))
+
+	// Match on resourceName ("Kind.group"); keep id (UUID) for deletion.
+	mcpResourceNames := make([]string, 0, len(mcpCaps))
+	idByResourceName := make(map[string]string, len(mcpCaps))
+	for _, capInfo := range mcpCaps {
+		if capInfo.ResourceName == "" {
+			continue
+		}
+		mcpResourceNames = append(mcpResourceNames, capInfo.ResourceName)
+		idByResourceName[capInfo.ResourceName] = capInfo.ID
+	}
+	logger.Info("Found MCP capabilities", "count", len(mcpResourceNames), "complete", mcpComplete)
 
 	// Compute diff
-	toScan, toDelete := computeCapabilityDiff(clusterResources, mcpCapabilities)
+	toScan, toDelete := computeCapabilityDiff(clusterResources, mcpResourceNames)
+
+	// A capability may be deleted only when both sides of the diff are provably
+	// complete. Scanning is additive and idempotent, so scanning missing
+	// resources is always safe; deleting from a truncated MCP list or a partial
+	// cluster discovery would remove valid capabilities and force expensive
+	// re-inference.
+	deletionsSafe := clusterComplete && mcpComplete
 
 	logger.Info("Computed capability diff",
 		"toScan", len(toScan),
 		"toDelete", len(toDelete),
+		"deletionsSafe", deletionsSafe,
 	)
 
 	// Scan missing resources (if any)
@@ -271,18 +290,41 @@ func (r *CapabilityScanReconciler) performStartupReconciliation(ctx context.Cont
 		}
 	}
 
-	// Delete orphaned capabilities (if any)
-	if len(toDelete) > 0 {
+	// Delete orphaned capabilities (only when the diff is provably complete)
+	switch {
+	case len(toDelete) == 0:
+		// nothing to delete
+	case deletionsSafe:
 		logger.Info("Deleting orphaned capabilities", "count", len(toDelete))
-		for _, id := range toDelete {
+		for _, resourceName := range toDelete {
+			id := idByResourceName[resourceName]
+			if id == "" {
+				id = resourceName
+			}
 			if err := state.mcpClient.DeleteCapability(ctx, id); err != nil {
-				logger.Error(err, "❌ Failed to delete orphaned capability", "id", id)
+				logger.Error(err, "❌ Failed to delete orphaned capability", "resource", resourceName, "id", id)
 				// Continue deleting others even if one fails
 			} else {
-				logger.V(1).Info("Deleted orphaned capability", "id", id)
+				logger.V(1).Info("Deleted orphaned capability", "resource", resourceName, "id", id)
 			}
 		}
 		logger.Info("✅ Orphaned capabilities cleanup complete")
+	default:
+		logger.Info("Skipping orphaned-capability deletion: resource list is incomplete",
+			"toDelete", len(toDelete),
+			"clusterComplete", clusterComplete,
+			"mcpComplete", mcpComplete,
+		)
+	}
+
+	// Record diff completeness so an incomplete-but-functioning state is visible
+	// rather than looking healthier than it is.
+	if deletionsSafe {
+		r.recordDiffCompleteness(ctx, configKey, true, "DiffComplete",
+			"Cluster and MCP resource lists are complete; full diff applied")
+	} else {
+		r.recordDiffCompleteness(ctx, configKey, false, "IncompleteResourceList",
+			incompletenessMessage(clusterComplete, mcpComplete))
 	}
 
 	if len(toScan) == 0 && len(toDelete) == 0 {
@@ -322,6 +364,66 @@ func computeCapabilityDiff(clusterCRDs, mcpCapabilities []string) (toScan, toDel
 	}
 
 	return toScan, toDelete
+}
+
+// incompletenessMessage explains why orphaned-capability deletions were
+// suppressed for a given completeness state.
+func incompletenessMessage(clusterComplete, mcpComplete bool) string {
+	switch {
+	case !clusterComplete && !mcpComplete:
+		return "Cluster discovery and MCP capability list are both incomplete; deletions suppressed to avoid removing valid capabilities"
+	case !clusterComplete:
+		return "Cluster discovery returned partial results; deletions suppressed to avoid removing valid capabilities"
+	default:
+		return "MCP capability list was truncated; deletions suppressed to avoid removing valid capabilities"
+	}
+}
+
+// upsertCondition sets or replaces a condition by type, preserving
+// LastTransitionTime when the status is unchanged.
+func upsertCondition(conditions []metav1.Condition, cond metav1.Condition) []metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == cond.Type {
+			if conditions[i].Status == cond.Status {
+				cond.LastTransitionTime = conditions[i].LastTransitionTime
+			}
+			conditions[i] = cond
+			return conditions
+		}
+	}
+	return append(conditions, cond)
+}
+
+// recordDiffCompleteness sets the DiffComplete condition, which reports whether
+// the last reconcile could safely apply deletions. It is deliberately separate
+// from Ready: a config with an incomplete diff is degraded but still functioning
+// (scans still happen), so it must not look either healthier or unhealthier than
+// it is.
+func (r *CapabilityScanReconciler) recordDiffCompleteness(ctx context.Context, key string, complete bool, reason, message string) {
+	logger := logf.Log.WithName("capabilityscan")
+
+	namespace, name := parseConfigKey(key)
+	fresh := &dotaiv1alpha1.CapabilityScanConfig{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, fresh); err != nil {
+		logger.V(1).Info("Failed to fetch CapabilityScanConfig for DiffComplete update", "error", err)
+		return
+	}
+
+	status := metav1.ConditionTrue
+	if !complete {
+		status = metav1.ConditionFalse
+	}
+	fresh.Status.Conditions = upsertCondition(fresh.Status.Conditions, metav1.Condition{
+		Type:               "DiffComplete",
+		Status:             status,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		Reason:             reason,
+		Message:            message,
+	})
+
+	if err := r.Status().Update(ctx, fresh); err != nil && !apierrors.IsConflict(err) {
+		logger.Error(err, "Failed to update DiffComplete condition")
+	}
 }
 
 // HandleCRDEvent processes CRD create/delete events by queuing them to the debounce buffer
@@ -404,20 +506,24 @@ func (r *CapabilityScanReconciler) listClusterCRDIDs(ctx context.Context, config
 
 // listAllResourceIDs lists ALL resource types (core + CRDs) using Discovery API
 // and returns their capability IDs with filters applied
-func (r *CapabilityScanReconciler) listAllResourceIDs(ctx context.Context, config *dotaiv1alpha1.CapabilityScanConfig) ([]string, error) {
+func (r *CapabilityScanReconciler) listAllResourceIDs(ctx context.Context, config *dotaiv1alpha1.CapabilityScanConfig) ([]string, bool, error) {
 	logger := logf.FromContext(ctx).WithName("capabilityscan")
 
 	if r.discoveryClient == nil {
-		return nil, fmt.Errorf("discovery client not initialized")
+		return nil, false, fmt.Errorf("discovery client not initialized")
 	}
 
-	// Get all API resources using Discovery API
+	// Get all API resources using Discovery API. Discovery can return partial
+	// results with errors for unavailable API groups (e.g. an aggregated
+	// APIService mid-restart); the list is then usable but incomplete, which
+	// must suppress deletions downstream.
+	complete := true
 	_, resources, err := r.discoveryClient.ServerGroupsAndResources()
 	if err != nil {
-		// Discovery can return partial results with errors for unavailable API groups
 		if !discovery.IsGroupDiscoveryFailedError(err) {
-			return nil, fmt.Errorf("failed to discover API resources: %w", err)
+			return nil, false, fmt.Errorf("failed to discover API resources: %w", err)
 		}
+		complete = false
 		logger.V(1).Info("Partial discovery failure (some API groups unavailable)", "error", err)
 	}
 
@@ -466,7 +572,7 @@ func (r *CapabilityScanReconciler) listAllResourceIDs(ctx context.Context, confi
 		}
 	}
 
-	return ids, nil
+	return ids, complete, nil
 }
 
 // shouldProcessResource checks if a resource matches include/exclude filters

--- a/internal/controller/capabilityscan_controller.go
+++ b/internal/controller/capabilityscan_controller.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
@@ -299,7 +300,10 @@ func (r *CapabilityScanReconciler) performStartupReconciliation(ctx context.Cont
 		for _, resourceName := range toDelete {
 			id := idByResourceName[resourceName]
 			if id == "" {
-				id = resourceName
+				// No server-side UUID: deleting by resourceName cannot match by
+				// ID, so skip and let the next reconcile retry once MCP has an id.
+				logger.Info("Skipping orphaned capability without an MCP id", "resource", resourceName)
+				continue
 			}
 			if err := state.mcpClient.DeleteCapability(ctx, id); err != nil {
 				logger.Error(err, "❌ Failed to delete orphaned capability", "resource", resourceName, "id", id)
@@ -379,21 +383,6 @@ func incompletenessMessage(clusterComplete, mcpComplete bool) string {
 	}
 }
 
-// upsertCondition sets or replaces a condition by type, preserving
-// LastTransitionTime when the status is unchanged.
-func upsertCondition(conditions []metav1.Condition, cond metav1.Condition) []metav1.Condition {
-	for i := range conditions {
-		if conditions[i].Type == cond.Type {
-			if conditions[i].Status == cond.Status {
-				cond.LastTransitionTime = conditions[i].LastTransitionTime
-			}
-			conditions[i] = cond
-			return conditions
-		}
-	}
-	return append(conditions, cond)
-}
-
 // recordDiffCompleteness sets the DiffComplete condition, which reports whether
 // the last reconcile could safely apply deletions. It is deliberately separate
 // from Ready: a config with an incomplete diff is degraded but still functioning
@@ -413,10 +402,10 @@ func (r *CapabilityScanReconciler) recordDiffCompleteness(ctx context.Context, k
 	if !complete {
 		status = metav1.ConditionFalse
 	}
-	fresh.Status.Conditions = upsertCondition(fresh.Status.Conditions, metav1.Condition{
+	meta.SetStatusCondition(&fresh.Status.Conditions, metav1.Condition{
 		Type:               "DiffComplete",
 		Status:             status,
-		LastTransitionTime: metav1.NewTime(time.Now()),
+		ObservedGeneration: fresh.Generation,
 		Reason:             reason,
 		Message:            message,
 	})

--- a/internal/controller/capabilityscan_mcp.go
+++ b/internal/controller/capabilityscan_mcp.go
@@ -44,10 +44,13 @@ type CapabilityInfo struct {
 
 // ManageOrgDataListData holds the list payload. The MCP server nests it under
 // result.data (i.e. data.result.data.{capabilities,totalCount,returnedCount}).
+// TotalCount and ReturnedCount are pointers so an omitted count is distinguished
+// from a real zero; a missing count leaves completeness unproven and must block
+// deletions rather than pass a 0 == 0 check.
 type ManageOrgDataListData struct {
 	Capabilities  []CapabilityInfo `json:"capabilities,omitempty"`
-	TotalCount    int              `json:"totalCount,omitempty"`
-	ReturnedCount int              `json:"returnedCount,omitempty"`
+	TotalCount    *int             `json:"totalCount,omitempty"`
+	ReturnedCount *int             `json:"returnedCount,omitempty"`
 }
 
 // ManageOrgDataResult is the operation result nested under data.result.
@@ -103,19 +106,20 @@ func (r *ManageOrgDataResponse) GetErrorMessage() string {
 	return "unknown error"
 }
 
-// HasResultError reports whether the envelope succeeded but the nested
-// operation result reports a failure. manageOrgData catches every error and
-// returns HTTP 200 with the transport Success flag set, so the operation
-// outcome only lives in data.result.success.
+// HasResultError reports whether the operation failed. manageOrgData catches
+// every error and returns HTTP 200 with the transport Success flag set, so the
+// operation outcome only lives in data.result.success. A missing nested result
+// is itself a failure: a bare {"success": true} envelope must not be accepted
+// as a completed operation.
 func (r *ManageOrgDataResponse) HasResultError() bool {
 	res := r.result()
-	return res != nil && !res.Success
+	return res == nil || !res.Success
 }
 
 // GetTotalCount returns the total count of capabilities from a list response
 func (r *ManageOrgDataResponse) GetTotalCount() int {
-	if res := r.result(); res != nil && res.Data != nil {
-		return res.Data.TotalCount
+	if res := r.result(); res != nil && res.Data != nil && res.Data.TotalCount != nil {
+		return *res.Data.TotalCount
 	}
 	return 0
 }
@@ -132,13 +136,15 @@ func (r *ManageOrgDataResponse) GetCapabilities() []CapabilityInfo {
 // IsListComplete reports whether a list response returned every capability.
 // The server does not cap totalCount, so returnedCount == totalCount proves the
 // list is complete even against a server that still limits the returned page.
-// An empty collection (both zero) is complete.
+// An empty collection (both zero) is complete. Both counts must be present: an
+// omitted count leaves completeness unproven, which must block deletions.
 func (r *ManageOrgDataResponse) IsListComplete() bool {
 	res := r.result()
 	if res == nil || res.Data == nil {
 		return false
 	}
-	return res.Data.ReturnedCount == res.Data.TotalCount
+	d := res.Data
+	return d.TotalCount != nil && d.ReturnedCount != nil && *d.ReturnedCount == *d.TotalCount
 }
 
 // MCPCapabilityScanClient handles HTTP communication with the MCP capability scan endpoint

--- a/internal/controller/capabilityscan_mcp.go
+++ b/internal/controller/capabilityscan_mcp.go
@@ -34,28 +34,57 @@ type ManageOrgDataRequest struct {
 	Limit        int    `json:"limit,omitempty"`        // For list operation
 }
 
-// CapabilityInfo represents a capability returned from MCP
+// CapabilityInfo represents a capability returned from MCP.
+// ID is a UUID used for deletion; ResourceName is the "Kind.group" identifier
+// used to match capabilities against cluster resources during diffing.
 type CapabilityInfo struct {
-	ID string `json:"id"`
+	ID           string `json:"id"`
+	ResourceName string `json:"resourceName"`
+}
+
+// ManageOrgDataListData holds the list payload. The MCP server nests it under
+// result.data (i.e. data.result.data.{capabilities,totalCount,returnedCount}).
+type ManageOrgDataListData struct {
+	Capabilities  []CapabilityInfo `json:"capabilities,omitempty"`
+	TotalCount    int              `json:"totalCount,omitempty"`
+	ReturnedCount int              `json:"returnedCount,omitempty"`
+}
+
+// ManageOrgDataResult is the operation result nested under data.result.
+// Success here is the operation outcome, distinct from the transport-level
+// Success on ManageOrgDataResponse.
+type ManageOrgDataResult struct {
+	Success   bool                   `json:"success"`
+	Status    string                 `json:"status,omitempty"`
+	Message   string                 `json:"message,omitempty"`
+	Operation string                 `json:"operation,omitempty"`
+	Data      *ManageOrgDataListData `json:"data,omitempty"`
+}
+
+// ManageOrgDataEnvelope is the data envelope nested under the top-level data.
+type ManageOrgDataEnvelope struct {
+	Result *ManageOrgDataResult `json:"result,omitempty"`
+}
+
+// ManageOrgDataError is the top-level error object.
+type ManageOrgDataError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
 // ManageOrgDataResponse is the response from POST /api/v1/tools/manageOrgData
 type ManageOrgDataResponse struct {
-	Success bool `json:"success"`
-	Data    *struct {
-		Result *struct {
-			Success      bool             `json:"success"`
-			Status       string           `json:"status,omitempty"`
-			Message      string           `json:"message,omitempty"`
-			Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-			TotalCount   int              `json:"totalCount,omitempty"`
-			Operation    string           `json:"operation,omitempty"`
-		} `json:"result,omitempty"`
-	} `json:"data,omitempty"`
-	Error *struct {
-		Code    string `json:"code"`
-		Message string `json:"message"`
-	} `json:"error,omitempty"`
+	Success bool                   `json:"success"`
+	Data    *ManageOrgDataEnvelope `json:"data,omitempty"`
+	Error   *ManageOrgDataError    `json:"error,omitempty"`
+}
+
+// result returns the nested operation result, or nil if absent.
+func (r *ManageOrgDataResponse) result() *ManageOrgDataResult {
+	if r.Data == nil {
+		return nil
+	}
+	return r.Data.Result
 }
 
 // GetErrorMessage extracts error message from the response
@@ -68,32 +97,48 @@ func (r *ManageOrgDataResponse) GetErrorMessage() string {
 			return fmt.Sprintf("error code: %s", r.Error.Code)
 		}
 	}
-	if r.Data != nil && r.Data.Result != nil && r.Data.Result.Message != "" {
-		return r.Data.Result.Message
+	if res := r.result(); res != nil && res.Message != "" {
+		return res.Message
 	}
 	return "unknown error"
 }
 
+// HasResultError reports whether the envelope succeeded but the nested
+// operation result reports a failure. manageOrgData catches every error and
+// returns HTTP 200 with the transport Success flag set, so the operation
+// outcome only lives in data.result.success.
+func (r *ManageOrgDataResponse) HasResultError() bool {
+	res := r.result()
+	return res != nil && !res.Success
+}
+
 // GetTotalCount returns the total count of capabilities from a list response
 func (r *ManageOrgDataResponse) GetTotalCount() int {
-	if r.Data != nil && r.Data.Result != nil {
-		return r.Data.Result.TotalCount
+	if res := r.result(); res != nil && res.Data != nil {
+		return res.Data.TotalCount
 	}
 	return 0
 }
 
-// GetCapabilityIDs returns the IDs of capabilities from a list response
-func (r *ManageOrgDataResponse) GetCapabilityIDs() []string {
-	if r.Data == nil || r.Data.Result == nil {
+// GetCapabilities returns the capabilities from a list response
+func (r *ManageOrgDataResponse) GetCapabilities() []CapabilityInfo {
+	res := r.result()
+	if res == nil || res.Data == nil {
 		return nil
 	}
-	ids := make([]string, 0, len(r.Data.Result.Capabilities))
-	for _, cap := range r.Data.Result.Capabilities {
-		if cap.ID != "" {
-			ids = append(ids, cap.ID)
-		}
+	return res.Data.Capabilities
+}
+
+// IsListComplete reports whether a list response returned every capability.
+// The server does not cap totalCount, so returnedCount == totalCount proves the
+// list is complete even against a server that still limits the returned page.
+// An empty collection (both zero) is complete.
+func (r *ManageOrgDataResponse) IsListComplete() bool {
+	res := r.result()
+	if res == nil || res.Data == nil {
+		return false
 	}
-	return ids
+	return res.Data.ReturnedCount == res.Data.TotalCount
 }
 
 // MCPCapabilityScanClient handles HTTP communication with the MCP capability scan endpoint
@@ -184,8 +229,12 @@ func (c *MCPCapabilityScanClient) ListCapabilities(ctx context.Context) (int, er
 	return resp.GetTotalCount(), nil
 }
 
-// ListCapabilityIDs returns all capability IDs from the database
-func (c *MCPCapabilityScanClient) ListCapabilityIDs(ctx context.Context) ([]string, error) {
+// ListCapabilityInfos returns all capabilities (id + resourceName) from the
+// database, along with whether the returned list is complete. Completeness is
+// derived from returnedCount == totalCount; because the server does not cap
+// totalCount, this holds even against a server that still limits the returned
+// page. An incomplete list must not drive deletions.
+func (c *MCPCapabilityScanClient) ListCapabilityInfos(ctx context.Context) ([]CapabilityInfo, bool, error) {
 	// Use a large limit to get all capabilities
 	// Most clusters have < 1000 CRDs, so this should be sufficient
 	req := ManageOrgDataRequest{
@@ -197,14 +246,14 @@ func (c *MCPCapabilityScanClient) ListCapabilityIDs(ctx context.Context) ([]stri
 
 	resp, err := c.sendWithRetry(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if !resp.Success {
-		return nil, fmt.Errorf("MCP returned error: %s", resp.GetErrorMessage())
+		return nil, false, fmt.Errorf("MCP returned error: %s", resp.GetErrorMessage())
 	}
 
-	return resp.GetCapabilityIDs(), nil
+	return resp.GetCapabilities(), resp.IsListComplete(), nil
 }
 
 // TriggerFullScan triggers a full cluster capability scan
@@ -293,7 +342,7 @@ func (c *MCPCapabilityScanClient) sendWithRetry(ctx context.Context, req ManageO
 		}
 
 		resp, err := c.send(ctx, req)
-		if err == nil && resp.Success {
+		if err == nil && resp.Success && !resp.HasResultError() {
 			return resp, nil
 		}
 
@@ -306,6 +355,17 @@ func (c *MCPCapabilityScanClient) sendWithRetry(ctx context.Context, req ManageO
 		} else if !resp.Success {
 			lastErr = fmt.Errorf("MCP returned error: %s", resp.GetErrorMessage())
 			logger.V(1).Info("MCP returned error response",
+				"attempt", attempt,
+				"error", resp.GetErrorMessage(),
+			)
+		} else {
+			// Envelope reports success but the operation result reports a
+			// failure (e.g. the vector backend is unavailable). Treat it as a
+			// retryable error so it is surfaced instead of masked as an empty
+			// result — otherwise a not-ready backend looks like an empty
+			// collection on a fresh install.
+			lastErr = fmt.Errorf("MCP operation failed: %s", resp.GetErrorMessage())
+			logger.V(1).Info("MCP operation reported failure",
 				"attempt", attempt,
 				"error", resp.GetErrorMessage(),
 			)
@@ -400,10 +460,7 @@ func (c *MCPCapabilityScanClient) send(ctx context.Context, req ManageOrgDataReq
 	if resp.StatusCode >= 400 {
 		return &ManageOrgDataResponse{
 			Success: false,
-			Error: &struct {
-				Code    string `json:"code"`
-				Message string `json:"message"`
-			}{
+			Error: &ManageOrgDataError{
 				Code:    fmt.Sprintf("%d", resp.StatusCode),
 				Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(responseBody)),
 			},

--- a/internal/controller/capabilityscan_mcp_test.go
+++ b/internal/controller/capabilityscan_mcp_test.go
@@ -14,92 +14,63 @@ import (
 func TestMCPCapabilityScanClient_ListCapabilities(t *testing.T) {
 	tests := []struct {
 		name           string
-		serverResponse ManageOrgDataResponse
+		serverResponse string // JSON response
 		serverStatus   int
 		wantCount      int
 		wantErr        bool
 	}{
 		{
 			name: "successful list with capabilities",
-			serverResponse: ManageOrgDataResponse{
-				Success: true,
-				Data: &struct {
-					Result *struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					} `json:"result,omitempty"`
-				}{
-					Result: &struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					}{
-						Success:    true,
-						TotalCount: 150,
-					},
-				},
-			},
+			serverResponse: `{
+				"success": true,
+				"data": {
+					"result": {
+						"success": true,
+						"data": {
+							"totalCount": 150,
+							"returnedCount": 150
+						}
+					}
+				}
+			}`,
 			serverStatus: http.StatusOK,
 			wantCount:    150,
 			wantErr:      false,
 		},
 		{
 			name: "successful list with zero capabilities",
-			serverResponse: ManageOrgDataResponse{
-				Success: true,
-				Data: &struct {
-					Result *struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					} `json:"result,omitempty"`
-				}{
-					Result: &struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					}{
-						Success:    true,
-						TotalCount: 0,
-					},
-				},
-			},
+			serverResponse: `{
+				"success": true,
+				"data": {
+					"result": {
+						"success": true,
+						"data": {
+							"totalCount": 0,
+							"returnedCount": 0
+						}
+					}
+				}
+			}`,
 			serverStatus: http.StatusOK,
 			wantCount:    0,
 			wantErr:      false,
 		},
 		{
 			name: "server error",
-			serverResponse: ManageOrgDataResponse{
-				Success: false,
-				Error: &struct {
-					Code    string `json:"code"`
-					Message string `json:"message"`
-				}{
-					Code:    "500",
-					Message: "Internal server error",
-				},
-			},
+			serverResponse: `{
+				"success": false,
+				"error": {
+					"code": "500",
+					"message": "Internal server error"
+				}
+			}`,
 			serverStatus: http.StatusOK,
 			wantCount:    0,
 			wantErr:      true,
 		},
 		{
 			name:           "HTTP error",
-			serverResponse: ManageOrgDataResponse{},
+			serverResponse: `{}`,
 			serverStatus:   http.StatusInternalServerError,
 			wantCount:      0,
 			wantErr:        true,
@@ -109,7 +80,6 @@ func TestMCPCapabilityScanClient_ListCapabilities(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				// Verify request
 				if r.Method != "POST" {
 					t.Errorf("Expected POST, got %s", r.Method)
 				}
@@ -117,13 +87,10 @@ func TestMCPCapabilityScanClient_ListCapabilities(t *testing.T) {
 					t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
 				}
 
-				// Parse request body
 				var req ManageOrgDataRequest
 				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 					t.Errorf("Failed to decode request: %v", err)
 				}
-
-				// Verify request fields
 				if req.DataType != "capabilities" {
 					t.Errorf("Expected dataType=capabilities, got %s", req.DataType)
 				}
@@ -132,14 +99,14 @@ func TestMCPCapabilityScanClient_ListCapabilities(t *testing.T) {
 				}
 
 				w.WriteHeader(tt.serverStatus)
-				json.NewEncoder(w).Encode(tt.serverResponse)
+				_, _ = w.Write([]byte(tt.serverResponse))
 			}))
 			defer server.Close()
 
 			client := NewMCPCapabilityScanClient(MCPCapabilityScanClientConfig{
 				Endpoint:       server.URL,
 				Collection:     "test-capabilities",
-				MaxRetries:     ptr.To(1),
+				MaxRetries:     ptr.To(0),
 				InitialBackoff: 10 * time.Millisecond,
 			})
 
@@ -156,67 +123,99 @@ func TestMCPCapabilityScanClient_ListCapabilities(t *testing.T) {
 	}
 }
 
-func TestMCPCapabilityScanClient_ListCapabilityIDs(t *testing.T) {
+func TestMCPCapabilityScanClient_ListCapabilityInfos(t *testing.T) {
 	tests := []struct {
-		name           string
-		serverResponse string // JSON response
-		serverStatus   int
-		wantIDs        []string
-		wantErr        bool
+		name              string
+		serverResponse    string // JSON response
+		serverStatus      int
+		wantResourceNames []string
+		wantComplete      bool
+		wantErr           bool
 	}{
 		{
-			name: "successful list with capabilities",
+			name: "successful complete list",
 			serverResponse: `{
 				"success": true,
 				"data": {
 					"result": {
 						"success": true,
-						"capabilities": [
-							{"id": "RDSInstance.database.aws.crossplane.io"},
-							{"id": "Bucket.s3.aws.crossplane.io"},
-							{"id": "Deployment.apps"}
-						],
-						"totalCount": 3
+						"data": {
+							"capabilities": [
+								{"id": "1111", "resourceName": "RDSInstance.database.aws.crossplane.io"},
+								{"id": "2222", "resourceName": "Bucket.s3.aws.crossplane.io"},
+								{"id": "3333", "resourceName": "Deployment.apps"}
+							],
+							"totalCount": 3,
+							"returnedCount": 3
+						}
 					}
 				}
 			}`,
-			serverStatus: http.StatusOK,
-			wantIDs:      []string{"RDSInstance.database.aws.crossplane.io", "Bucket.s3.aws.crossplane.io", "Deployment.apps"},
-			wantErr:      false,
+			serverStatus:      http.StatusOK,
+			wantResourceNames: []string{"RDSInstance.database.aws.crossplane.io", "Bucket.s3.aws.crossplane.io", "Deployment.apps"},
+			wantComplete:      true,
+			wantErr:           false,
 		},
 		{
-			name: "successful list with empty capabilities",
+			name: "truncated list is incomplete",
 			serverResponse: `{
 				"success": true,
 				"data": {
 					"result": {
 						"success": true,
-						"capabilities": [],
-						"totalCount": 0
+						"data": {
+							"capabilities": [
+								{"id": "1111", "resourceName": "RDSInstance.database.aws.crossplane.io"}
+							],
+							"totalCount": 250,
+							"returnedCount": 100
+						}
 					}
 				}
 			}`,
-			serverStatus: http.StatusOK,
-			wantIDs:      []string{},
-			wantErr:      false,
+			serverStatus:      http.StatusOK,
+			wantResourceNames: []string{"RDSInstance.database.aws.crossplane.io"},
+			wantComplete:      false,
+			wantErr:           false,
 		},
 		{
-			name: "successful list with nil capabilities",
+			name: "empty collection is complete",
 			serverResponse: `{
 				"success": true,
 				"data": {
 					"result": {
 						"success": true,
-						"totalCount": 0
+						"data": {
+							"capabilities": [],
+							"totalCount": 0,
+							"returnedCount": 0
+						}
 					}
 				}
 			}`,
-			serverStatus: http.StatusOK,
-			wantIDs:      []string{},
-			wantErr:      false,
+			serverStatus:      http.StatusOK,
+			wantResourceNames: []string{},
+			wantComplete:      true,
+			wantErr:           false,
 		},
 		{
-			name: "server error",
+			name: "inner success false surfaces as error",
+			serverResponse: `{
+				"success": true,
+				"data": {
+					"result": {
+						"success": false,
+						"message": "Vector DB (Qdrant) connection required"
+					}
+				}
+			}`,
+			serverStatus:      http.StatusOK,
+			wantResourceNames: nil,
+			wantComplete:      false,
+			wantErr:           true,
+		},
+		{
+			name: "envelope error",
 			serverResponse: `{
 				"success": false,
 				"error": {
@@ -224,35 +223,33 @@ func TestMCPCapabilityScanClient_ListCapabilityIDs(t *testing.T) {
 					"message": "Internal server error"
 				}
 			}`,
-			serverStatus: http.StatusOK,
-			wantIDs:      nil,
-			wantErr:      true,
+			serverStatus:      http.StatusOK,
+			wantResourceNames: nil,
+			wantComplete:      false,
+			wantErr:           true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				// Verify request
 				var req ManageOrgDataRequest
 				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 					t.Errorf("Failed to decode request: %v", err)
 				}
-
-				// Verify request fields
 				if req.DataType != "capabilities" {
 					t.Errorf("Expected dataType=capabilities, got %s", req.DataType)
 				}
 				if req.Operation != "list" {
 					t.Errorf("Expected operation=list, got %s", req.Operation)
 				}
-				// ListCapabilityIDs should use a large limit
+				// ListCapabilityInfos should use a large limit
 				if req.Limit < 1000 {
-					t.Errorf("Expected large limit for ListCapabilityIDs, got %d", req.Limit)
+					t.Errorf("Expected large limit for ListCapabilityInfos, got %d", req.Limit)
 				}
 
 				w.WriteHeader(tt.serverStatus)
-				w.Write([]byte(tt.serverResponse))
+				_, _ = w.Write([]byte(tt.serverResponse))
 			}))
 			defer server.Close()
 
@@ -263,21 +260,24 @@ func TestMCPCapabilityScanClient_ListCapabilityIDs(t *testing.T) {
 				InitialBackoff: 10 * time.Millisecond,
 			})
 
-			ids, err := client.ListCapabilityIDs(context.Background())
+			caps, complete, err := client.ListCapabilityInfos(context.Background())
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ListCapabilityIDs() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ListCapabilityInfos() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
-			if !tt.wantErr {
-				if len(ids) != len(tt.wantIDs) {
-					t.Errorf("ListCapabilityIDs() returned %d IDs, want %d", len(ids), len(tt.wantIDs))
-				}
-				for i, id := range ids {
-					if i < len(tt.wantIDs) && id != tt.wantIDs[i] {
-						t.Errorf("ListCapabilityIDs()[%d] = %s, want %s", i, id, tt.wantIDs[i])
-					}
+			if tt.wantErr {
+				return
+			}
+			if complete != tt.wantComplete {
+				t.Errorf("ListCapabilityInfos() complete = %v, want %v", complete, tt.wantComplete)
+			}
+			if len(caps) != len(tt.wantResourceNames) {
+				t.Errorf("ListCapabilityInfos() returned %d capabilities, want %d", len(caps), len(tt.wantResourceNames))
+			}
+			for i, c := range caps {
+				if i < len(tt.wantResourceNames) && c.ResourceName != tt.wantResourceNames[i] {
+					t.Errorf("ListCapabilityInfos()[%d].ResourceName = %s, want %s", i, c.ResourceName, tt.wantResourceNames[i])
 				}
 			}
 		})
@@ -287,53 +287,48 @@ func TestMCPCapabilityScanClient_ListCapabilityIDs(t *testing.T) {
 func TestMCPCapabilityScanClient_TriggerFullScan(t *testing.T) {
 	tests := []struct {
 		name           string
-		serverResponse ManageOrgDataResponse
+		serverResponse string
 		serverStatus   int
 		wantErr        bool
 	}{
 		{
 			name: "successful full scan",
-			serverResponse: ManageOrgDataResponse{
-				Success: true,
-				Data: &struct {
-					Result *struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					} `json:"result,omitempty"`
-				}{
-					Result: &struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					}{
-						Success: true,
-						Status:  "started",
-						Message: "Full capability scan initiated in background",
-					},
-				},
-			},
+			serverResponse: `{
+				"success": true,
+				"data": {
+					"result": {
+						"success": true,
+						"status": "started",
+						"message": "Full capability scan initiated in background"
+					}
+				}
+			}`,
 			serverStatus: http.StatusOK,
 			wantErr:      false,
 		},
 		{
-			name: "server returns error",
-			serverResponse: ManageOrgDataResponse{
-				Success: false,
-				Error: &struct {
-					Code    string `json:"code"`
-					Message string `json:"message"`
-				}{
-					Code:    "ERROR",
-					Message: "Scan failed",
-				},
-			},
+			name: "envelope error",
+			serverResponse: `{
+				"success": false,
+				"error": {
+					"code": "ERROR",
+					"message": "Scan failed"
+				}
+			}`,
+			serverStatus: http.StatusOK,
+			wantErr:      true,
+		},
+		{
+			name: "inner result failure",
+			serverResponse: `{
+				"success": true,
+				"data": {
+					"result": {
+						"success": false,
+						"message": "Vector DB (Qdrant) connection required"
+					}
+				}
+			}`,
 			serverStatus: http.StatusOK,
 			wantErr:      true,
 		},
@@ -346,8 +341,6 @@ func TestMCPCapabilityScanClient_TriggerFullScan(t *testing.T) {
 				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 					t.Errorf("Failed to decode request: %v", err)
 				}
-
-				// Verify request fields for full scan
 				if req.Operation != "scan" {
 					t.Errorf("Expected operation=scan, got %s", req.Operation)
 				}
@@ -356,14 +349,14 @@ func TestMCPCapabilityScanClient_TriggerFullScan(t *testing.T) {
 				}
 
 				w.WriteHeader(tt.serverStatus)
-				json.NewEncoder(w).Encode(tt.serverResponse)
+				_, _ = w.Write([]byte(tt.serverResponse))
 			}))
 			defer server.Close()
 
 			client := NewMCPCapabilityScanClient(MCPCapabilityScanClientConfig{
 				Endpoint:       server.URL,
 				Collection:     "test-capabilities",
-				MaxRetries:     ptr.To(1),
+				MaxRetries:     ptr.To(0),
 				InitialBackoff: 10 * time.Millisecond,
 			})
 
@@ -380,50 +373,32 @@ func TestMCPCapabilityScanClient_TriggerScan(t *testing.T) {
 	tests := []struct {
 		name           string
 		resourceList   string
-		serverResponse ManageOrgDataResponse
+		serverResponse string
 		serverStatus   int
 		wantErr        bool
 	}{
 		{
 			name:         "successful targeted scan",
 			resourceList: "RDSInstance.database.aws.crossplane.io",
-			serverResponse: ManageOrgDataResponse{
-				Success: true,
-				Data: &struct {
-					Result *struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					} `json:"result,omitempty"`
-				}{
-					Result: &struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					}{
-						Success: true,
-						Status:  "started",
-						Message: "Scan initiated for 1 resources",
-					},
-				},
-			},
+			serverResponse: `{
+				"success": true,
+				"data": {
+					"result": {
+						"success": true,
+						"status": "started",
+						"message": "Scan initiated for 1 resources"
+					}
+				}
+			}`,
 			serverStatus: http.StatusOK,
 			wantErr:      false,
 		},
 		{
-			name:         "multiple resources",
-			resourceList: "RDSInstance.database.aws.crossplane.io,Bucket.s3.aws.crossplane.io",
-			serverResponse: ManageOrgDataResponse{
-				Success: true,
-			},
-			serverStatus: http.StatusOK,
-			wantErr:      false,
+			name:           "multiple resources",
+			resourceList:   "RDSInstance.database.aws.crossplane.io,Bucket.s3.aws.crossplane.io",
+			serverResponse: `{"success": true}`,
+			serverStatus:   http.StatusOK,
+			wantErr:        false,
 		},
 	}
 
@@ -434,8 +409,6 @@ func TestMCPCapabilityScanClient_TriggerScan(t *testing.T) {
 				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 					t.Errorf("Failed to decode request: %v", err)
 				}
-
-				// Verify request fields for targeted scan
 				if req.Operation != "scan" {
 					t.Errorf("Expected operation=scan, got %s", req.Operation)
 				}
@@ -447,14 +420,14 @@ func TestMCPCapabilityScanClient_TriggerScan(t *testing.T) {
 				}
 
 				w.WriteHeader(tt.serverStatus)
-				json.NewEncoder(w).Encode(tt.serverResponse)
+				_, _ = w.Write([]byte(tt.serverResponse))
 			}))
 			defer server.Close()
 
 			client := NewMCPCapabilityScanClient(MCPCapabilityScanClientConfig{
 				Endpoint:       server.URL,
 				Collection:     "test-capabilities",
-				MaxRetries:     ptr.To(1),
+				MaxRetries:     ptr.To(0),
 				InitialBackoff: 10 * time.Millisecond,
 			})
 
@@ -471,55 +444,36 @@ func TestMCPCapabilityScanClient_DeleteCapability(t *testing.T) {
 	tests := []struct {
 		name           string
 		capabilityID   string
-		serverResponse ManageOrgDataResponse
+		serverResponse string
 		serverStatus   int
 		wantErr        bool
 	}{
 		{
 			name:         "successful delete",
-			capabilityID: "RDSInstance.database.aws.crossplane.io",
-			serverResponse: ManageOrgDataResponse{
-				Success: true,
-				Data: &struct {
-					Result *struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					} `json:"result,omitempty"`
-				}{
-					Result: &struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					}{
-						Success:   true,
-						Operation: "delete",
-						Message:   "Capability deleted successfully",
-					},
-				},
-			},
+			capabilityID: "1111-2222-3333",
+			serverResponse: `{
+				"success": true,
+				"data": {
+					"result": {
+						"success": true,
+						"operation": "delete",
+						"message": "Capability deleted successfully"
+					}
+				}
+			}`,
 			serverStatus: http.StatusOK,
 			wantErr:      false,
 		},
 		{
 			name:         "delete not found",
-			capabilityID: "NonExistent.example.com",
-			serverResponse: ManageOrgDataResponse{
-				Success: false,
-				Error: &struct {
-					Code    string `json:"code"`
-					Message string `json:"message"`
-				}{
-					Code:    "NOT_FOUND",
-					Message: "Capability not found",
-				},
-			},
+			capabilityID: "does-not-exist",
+			serverResponse: `{
+				"success": false,
+				"error": {
+					"code": "NOT_FOUND",
+					"message": "Capability not found"
+				}
+			}`,
 			serverStatus: http.StatusOK,
 			wantErr:      true,
 		},
@@ -532,8 +486,6 @@ func TestMCPCapabilityScanClient_DeleteCapability(t *testing.T) {
 				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 					t.Errorf("Failed to decode request: %v", err)
 				}
-
-				// Verify request fields for delete
 				if req.Operation != "delete" {
 					t.Errorf("Expected operation=delete, got %s", req.Operation)
 				}
@@ -542,14 +494,14 @@ func TestMCPCapabilityScanClient_DeleteCapability(t *testing.T) {
 				}
 
 				w.WriteHeader(tt.serverStatus)
-				json.NewEncoder(w).Encode(tt.serverResponse)
+				_, _ = w.Write([]byte(tt.serverResponse))
 			}))
 			defer server.Close()
 
 			client := NewMCPCapabilityScanClient(MCPCapabilityScanClientConfig{
 				Endpoint:       server.URL,
 				Collection:     "test-capabilities",
-				MaxRetries:     ptr.To(1),
+				MaxRetries:     ptr.To(0),
 				InitialBackoff: 10 * time.Millisecond,
 			})
 
@@ -569,45 +521,23 @@ func TestMCPCapabilityScanClient_RetryBehavior(t *testing.T) {
 		if attempts < 3 {
 			// Fail first 2 attempts
 			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(ManageOrgDataResponse{
-				Success: false,
-				Error: &struct {
-					Code    string `json:"code"`
-					Message string `json:"message"`
-				}{
-					Code:    "500",
-					Message: "Temporary error",
-				},
-			})
+			_, _ = w.Write([]byte(`{
+				"success": false,
+				"error": {"code": "500", "message": "Temporary error"}
+			}`))
 			return
 		}
 		// Succeed on 3rd attempt
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(ManageOrgDataResponse{
-			Success: true,
-			Data: &struct {
-				Result *struct {
-					Success      bool             `json:"success"`
-					Status       string           `json:"status,omitempty"`
-					Message      string           `json:"message,omitempty"`
-					Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-					TotalCount   int              `json:"totalCount,omitempty"`
-					Operation    string           `json:"operation,omitempty"`
-				} `json:"result,omitempty"`
-			}{
-				Result: &struct {
-					Success      bool             `json:"success"`
-					Status       string           `json:"status,omitempty"`
-					Message      string           `json:"message,omitempty"`
-					Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-					TotalCount   int              `json:"totalCount,omitempty"`
-					Operation    string           `json:"operation,omitempty"`
-				}{
-					Success:    true,
-					TotalCount: 10,
-				},
-			},
-		})
+		_, _ = w.Write([]byte(`{
+			"success": true,
+			"data": {
+				"result": {
+					"success": true,
+					"data": {"totalCount": 10, "returnedCount": 10}
+				}
+			}
+		}`))
 	}))
 	defer server.Close()
 
@@ -629,6 +559,43 @@ func TestMCPCapabilityScanClient_RetryBehavior(t *testing.T) {
 	}
 	if attempts != 3 {
 		t.Errorf("Expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestMCPCapabilityScanClient_RetriesOnInnerFailure(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		// Envelope always succeeds, but the operation result reports a failure.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"success": true,
+			"data": {
+				"result": {
+					"success": false,
+					"message": "Vector DB (Qdrant) connection required"
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewMCPCapabilityScanClient(MCPCapabilityScanClientConfig{
+		Endpoint:       server.URL,
+		Collection:     "test-capabilities",
+		MaxRetries:     ptr.To(2),
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	})
+
+	_, _, err := client.ListCapabilityInfos(context.Background())
+
+	if err == nil {
+		t.Errorf("Expected error when inner result reports failure, got nil")
+	}
+	// initial attempt + 2 retries
+	if attempts != 3 {
+		t.Errorf("Expected 3 attempts on inner failure, got %d", attempts)
 	}
 }
 
@@ -677,10 +644,7 @@ func TestManageOrgDataResponse_GetErrorMessage(t *testing.T) {
 		{
 			name: "error with message",
 			response: ManageOrgDataResponse{
-				Error: &struct {
-					Code    string `json:"code"`
-					Message string `json:"message"`
-				}{
+				Error: &ManageOrgDataError{
 					Code:    "ERROR",
 					Message: "Something went wrong",
 				},
@@ -690,10 +654,7 @@ func TestManageOrgDataResponse_GetErrorMessage(t *testing.T) {
 		{
 			name: "error with code only",
 			response: ManageOrgDataResponse{
-				Error: &struct {
-					Code    string `json:"code"`
-					Message string `json:"message"`
-				}{
+				Error: &ManageOrgDataError{
 					Code: "ERR_500",
 				},
 			},
@@ -702,24 +663,8 @@ func TestManageOrgDataResponse_GetErrorMessage(t *testing.T) {
 		{
 			name: "message in result",
 			response: ManageOrgDataResponse{
-				Data: &struct {
-					Result *struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					} `json:"result,omitempty"`
-				}{
-					Result: &struct {
-						Success      bool             `json:"success"`
-						Status       string           `json:"status,omitempty"`
-						Message      string           `json:"message,omitempty"`
-						Capabilities []CapabilityInfo `json:"capabilities,omitempty"`
-						TotalCount   int              `json:"totalCount,omitempty"`
-						Operation    string           `json:"operation,omitempty"`
-					}{
+				Data: &ManageOrgDataEnvelope{
+					Result: &ManageOrgDataResult{
 						Message: "Result message",
 					},
 				},
@@ -738,6 +683,55 @@ func TestManageOrgDataResponse_GetErrorMessage(t *testing.T) {
 			got := tt.response.GetErrorMessage()
 			if got != tt.want {
 				t.Errorf("GetErrorMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManageOrgDataResponse_IsListComplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		response ManageOrgDataResponse
+		want     bool
+	}{
+		{
+			name: "returned equals total",
+			response: ManageOrgDataResponse{
+				Data: &ManageOrgDataEnvelope{Result: &ManageOrgDataResult{
+					Data: &ManageOrgDataListData{TotalCount: 5, ReturnedCount: 5},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "returned less than total",
+			response: ManageOrgDataResponse{
+				Data: &ManageOrgDataEnvelope{Result: &ManageOrgDataResult{
+					Data: &ManageOrgDataListData{TotalCount: 250, ReturnedCount: 100},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "empty collection",
+			response: ManageOrgDataResponse{
+				Data: &ManageOrgDataEnvelope{Result: &ManageOrgDataResult{
+					Data: &ManageOrgDataListData{TotalCount: 0, ReturnedCount: 0},
+				}},
+			},
+			want: true,
+		},
+		{
+			name:     "no data is not complete",
+			response: ManageOrgDataResponse{},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.response.IsListComplete(); got != tt.want {
+				t.Errorf("IsListComplete() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/controller/capabilityscan_mcp_test.go
+++ b/internal/controller/capabilityscan_mcp_test.go
@@ -129,6 +129,7 @@ func TestMCPCapabilityScanClient_ListCapabilityInfos(t *testing.T) {
 		serverResponse    string // JSON response
 		serverStatus      int
 		wantResourceNames []string
+		wantIDs           []string
 		wantComplete      bool
 		wantErr           bool
 	}{
@@ -153,6 +154,7 @@ func TestMCPCapabilityScanClient_ListCapabilityInfos(t *testing.T) {
 			}`,
 			serverStatus:      http.StatusOK,
 			wantResourceNames: []string{"RDSInstance.database.aws.crossplane.io", "Bucket.s3.aws.crossplane.io", "Deployment.apps"},
+			wantIDs:           []string{"1111", "2222", "3333"},
 			wantComplete:      true,
 			wantErr:           false,
 		},
@@ -175,6 +177,7 @@ func TestMCPCapabilityScanClient_ListCapabilityInfos(t *testing.T) {
 			}`,
 			serverStatus:      http.StatusOK,
 			wantResourceNames: []string{"RDSInstance.database.aws.crossplane.io"},
+			wantIDs:           []string{"1111"},
 			wantComplete:      false,
 			wantErr:           false,
 		},
@@ -278,6 +281,9 @@ func TestMCPCapabilityScanClient_ListCapabilityInfos(t *testing.T) {
 			for i, c := range caps {
 				if i < len(tt.wantResourceNames) && c.ResourceName != tt.wantResourceNames[i] {
 					t.Errorf("ListCapabilityInfos()[%d].ResourceName = %s, want %s", i, c.ResourceName, tt.wantResourceNames[i])
+				}
+				if i < len(tt.wantIDs) && c.ID != tt.wantIDs[i] {
+					t.Errorf("ListCapabilityInfos()[%d].ID = %s, want %s", i, c.ID, tt.wantIDs[i])
 				}
 			}
 		})
@@ -394,11 +400,27 @@ func TestMCPCapabilityScanClient_TriggerScan(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:           "multiple resources",
-			resourceList:   "RDSInstance.database.aws.crossplane.io,Bucket.s3.aws.crossplane.io",
+			name:         "multiple resources",
+			resourceList: "RDSInstance.database.aws.crossplane.io,Bucket.s3.aws.crossplane.io",
+			serverResponse: `{
+				"success": true,
+				"data": {
+					"result": {
+						"success": true,
+						"status": "started",
+						"message": "Scan initiated for 2 resources"
+					}
+				}
+			}`,
+			serverStatus: http.StatusOK,
+			wantErr:      false,
+		},
+		{
+			name:           "missing nested result is a failure",
+			resourceList:   "RDSInstance.database.aws.crossplane.io",
 			serverResponse: `{"success": true}`,
 			serverStatus:   http.StatusOK,
-			wantErr:        false,
+			wantErr:        true,
 		},
 	}
 
@@ -698,7 +720,7 @@ func TestManageOrgDataResponse_IsListComplete(t *testing.T) {
 			name: "returned equals total",
 			response: ManageOrgDataResponse{
 				Data: &ManageOrgDataEnvelope{Result: &ManageOrgDataResult{
-					Data: &ManageOrgDataListData{TotalCount: 5, ReturnedCount: 5},
+					Data: &ManageOrgDataListData{TotalCount: ptr.To(5), ReturnedCount: ptr.To(5)},
 				}},
 			},
 			want: true,
@@ -707,7 +729,7 @@ func TestManageOrgDataResponse_IsListComplete(t *testing.T) {
 			name: "returned less than total",
 			response: ManageOrgDataResponse{
 				Data: &ManageOrgDataEnvelope{Result: &ManageOrgDataResult{
-					Data: &ManageOrgDataListData{TotalCount: 250, ReturnedCount: 100},
+					Data: &ManageOrgDataListData{TotalCount: ptr.To(250), ReturnedCount: ptr.To(100)},
 				}},
 			},
 			want: false,
@@ -716,10 +738,19 @@ func TestManageOrgDataResponse_IsListComplete(t *testing.T) {
 			name: "empty collection",
 			response: ManageOrgDataResponse{
 				Data: &ManageOrgDataEnvelope{Result: &ManageOrgDataResult{
-					Data: &ManageOrgDataListData{TotalCount: 0, ReturnedCount: 0},
+					Data: &ManageOrgDataListData{TotalCount: ptr.To(0), ReturnedCount: ptr.To(0)},
 				}},
 			},
 			want: true,
+		},
+		{
+			name: "omitted counts is not complete",
+			response: ManageOrgDataResponse{
+				Data: &ManageOrgDataEnvelope{Result: &ManageOrgDataResult{
+					Data: &ManageOrgDataListData{},
+				}},
+			},
+			want: false,
 		},
 		{
 			name:     "no data is not complete",


### PR DESCRIPTION
Fixes #55.

This lands incrementally against PRD #55. Milestones:

- [x] **M1 — Correct contract, with guards**
- [ ] M2 — Truthful status
- [ ] M3 — Tests that would have caught this
- [ ] M4 — Periodic resync
- [ ] M5 — Completion feedback
- [ ] M6 — Docs and release

### Verification against a real MCP server (M1 acceptance bar)

Verified against a live dot-ai MCP server (real Qdrant + embeddings) on a local kind cluster — not the e2e mock. Three checks, all green:

1. **Captured the real `manageOrgData` list response.** Seeded one deterministic capability (`StatefulSet.apps`) and pulled the raw JSON. Confirms the shape this milestone targets: payload nested at `data.result.data.capabilities`, `resourceName` distinct from the delete `id` (a UUID), and the real outcome in `data.result.success` while the envelope stays 200 / `success: true`. The list also came back with `limit: 100` despite requesting 10000 — the exact truncation the completeness guard exists for.
2. **Parsed it through the new structs.** The captured response deserializes cleanly; `GetCapabilities()` yields the resourceName/id pair, and `IsListComplete()` reads `returnedCount == totalCount` correctly (including the omitted-count → incomplete case, since the counts are `*int`).
3. **Exercised the live client path.** Built `MCPCapabilityScanClient` from this branch and called `ListCapabilityInfos` in-process against the server over a port-forward — the exact spot that was misparsing before. Returns the right capabilities and completeness, and the guard suppresses deletions when the list can't be proven complete.